### PR TITLE
Fix lag caused by keyboard polling

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.15-GTNH:dev")
-    runtimeOnly("com.github.GTNewHorizons:CodeChickenLib:1.1.5.4:dev")
-    compileOnly("curse.maven:cofh-core-69162:2388751")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.3.23-GTNH:dev")
+    compileOnly("curse.maven:cofh-core-69162:2388750-dev:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,3 +58,6 @@ containsMixinsAndOrCoreModOnly = false
 # If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
+
+# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+includeWellKnownRepositories = true

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,14 +1,4 @@
 // Add any additional repositiroes for your dependencies here
 
 repositories {
-    maven {
-        name = "GTNH"
-        url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-    }
-    maven {
-        url "https://cursemaven.com"
-    }
-    maven {
-        url = "https://jitpack.io"
-    }
 }

--- a/src/main/java/com/enderio/core/client/handlers/ClientHandler.java
+++ b/src/main/java/com/enderio/core/client/handlers/ClientHandler.java
@@ -1,5 +1,7 @@
 package com.enderio.core.client.handlers;
 
+import org.lwjgl.input.Keyboard;
+
 import com.enderio.core.common.Handlers.Handler;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -10,13 +12,21 @@ import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 public class ClientHandler {
 
     private static int ticksElapsed;
+    private static boolean shiftDown = false;
 
     public static int getTicksElapsed() {
         return ticksElapsed;
     }
 
+    public static boolean isShiftDown() {
+        return shiftDown;
+    }
+
     @SubscribeEvent
     public void onClientTick(ClientTickEvent event) {
+        if (event.phase == Phase.START) {
+            shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+        }
         if (event.phase == Phase.END) {
             ticksElapsed++;
         }

--- a/src/main/java/com/enderio/core/client/handlers/OreDictTooltipHandler.java
+++ b/src/main/java/com/enderio/core/client/handlers/OreDictTooltipHandler.java
@@ -7,8 +7,6 @@ import net.minecraft.item.Item;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
-import org.lwjgl.input.Keyboard;
-
 import com.enderio.core.EnderCore;
 import com.enderio.core.common.Handlers.Handler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -18,7 +16,7 @@ public class OreDictTooltipHandler {
 
     @SubscribeEvent
     public void onItemTooltip(ItemTooltipEvent event) {
-        boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+        boolean shiftDown = ClientHandler.isShiftDown();
         boolean debugMode = Minecraft.getMinecraft().gameSettings.advancedItemTooltips;
         boolean doRegistry = showRegistryNameTooltips == 3 ? debugMode
                 : showRegistryNameTooltips == 2 ? shiftDown : showRegistryNameTooltips == 1;

--- a/src/main/java/com/enderio/core/client/handlers/SpecialTooltipHandler.java
+++ b/src/main/java/com/enderio/core/client/handlers/SpecialTooltipHandler.java
@@ -18,8 +18,6 @@ import net.minecraft.item.ItemTool;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 
-import org.lwjgl.input.Keyboard;
-
 import com.enderio.core.EnderCore;
 import com.enderio.core.api.client.gui.IAdvancedTooltipProvider;
 import com.enderio.core.api.client.gui.IResourceTooltipProvider;
@@ -152,7 +150,7 @@ public enum SpecialTooltipHandler {
     }
 
     public static boolean showAdvancedTooltips() {
-        return Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+        return ClientHandler.isShiftDown();
     }
 
     public static void addDetailedTooltipFromResources(List list, String unlocalizedName) {


### PR DESCRIPTION
Only polls Shift keys once a client tick instead of every time an item tooltip is requested.