### PR TITLE
Thread Safety

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/com/enderio/core/client/render/CubeRenderer.java
+++ b/src/main/java/com/enderio/core/client/render/CubeRenderer.java
@@ -10,18 +10,24 @@ import com.enderio.core.common.vecmath.Vector3d;
 
 public final class CubeRenderer {
 
-    public static final Vector3d[] verts = new Vector3d[8];
-    static {
+    private static final ThreadLocal<CubeRenderer> instance = ThreadLocal.withInitial(CubeRenderer::new);
+    public final Vector3d[] verts = new Vector3d[8];
+
+    public CubeRenderer() {
         for (int i = 0; i < verts.length; i++) {
             verts[i] = new Vector3d();
         }
     }
 
-    public static void render(Block block, int meta) {
+    public static CubeRenderer get() {
+        return instance.get();
+    }
+
+    public void render(Block block, int meta) {
         render(block, meta, null);
     }
 
-    public static void render(Block block, int meta, VertexTransform xForm) {
+    public void render(Block block, int meta, VertexTransform xForm) {
         IIcon[] icons = new IIcon[6];
         for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
             icons[dir.ordinal()] = block.getIcon(dir.ordinal(), meta);
@@ -29,20 +35,19 @@ public final class CubeRenderer {
         render(BoundingBox.UNIT_CUBE.translate(0, -0.1f, 0), icons, xForm, true);
     }
 
-    public static void render(BoundingBox bb, IIcon tex) {
+    public void render(BoundingBox bb, IIcon tex) {
         render(bb, tex, null, false);
     }
 
-    public static void render(BoundingBox bb, IIcon tex, boolean tintSides) {
+    public void render(BoundingBox bb, IIcon tex, boolean tintSides) {
         render(bb, tex, null, tintSides);
     }
 
-    public static void render(BoundingBox bb, IIcon tex, VertexTransform xForm) {
+    public void render(BoundingBox bb, IIcon tex, VertexTransform xForm) {
         render(bb, tex.getMinU(), tex.getMaxU(), tex.getMinV(), tex.getMaxV(), xForm, false);
     }
 
-    public static void render(BoundingBox bb, IIcon tex, VertexTransform xForm, float[] brightnessPerSide,
-            boolean tintSides) {
+    public void render(BoundingBox bb, IIcon tex, VertexTransform xForm, float[] brightnessPerSide, boolean tintSides) {
         float minU = 0;
         float minV = 0;
         float maxU = 1;
@@ -56,7 +61,7 @@ public final class CubeRenderer {
         render(bb, minU, maxU, minV, maxV, xForm, brightnessPerSide, tintSides);
     }
 
-    public static void render(BoundingBox bb, IIcon tex, VertexTransform xForm, boolean tintSides) {
+    public void render(BoundingBox bb, IIcon tex, VertexTransform xForm, boolean tintSides) {
         float minU = 0;
         float minV = 0;
         float maxU = 1;
@@ -70,19 +75,19 @@ public final class CubeRenderer {
         render(bb, minU, maxU, minV, maxV, xForm, tintSides);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, boolean tintSides) {
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, boolean tintSides) {
         render(bb, minU, maxU, minV, maxV, null, tintSides);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV) {
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV) {
         render(bb, minU, maxU, minV, maxV, null, false);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm) {
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm) {
         render(bb, minU, maxU, minV, maxV, xForm, false);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
             boolean tintSides) {
         float[] brightnessPerSide = null;
         if (tintSides) {
@@ -94,7 +99,7 @@ public final class CubeRenderer {
         render(bb, minU, maxU, minV, maxV, xForm, brightnessPerSide);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
             float[] brightnessPerSide, boolean tintSides) {
 
         if (tintSides) {
@@ -110,7 +115,7 @@ public final class CubeRenderer {
         render(bb, minU, maxU, minV, maxV, xForm, brightnessPerSide);
     }
 
-    public static void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
+    public void render(BoundingBox bb, float minU, float maxU, float minV, float maxV, VertexTransform xForm,
             float[] brightnessPerSide) {
 
         if (brightnessPerSide != null && brightnessPerSide.length != 6) {
@@ -186,7 +191,7 @@ public final class CubeRenderer {
         addVecWithUV(verts[3], minU, maxV);
     }
 
-    public static void render(BoundingBox bb, IIcon[] icons, boolean tintSides) {
+    public void render(BoundingBox bb, IIcon[] icons, boolean tintSides) {
         float[] brightnessPerSide = null;
         if (tintSides) {
             brightnessPerSide = new float[6];
@@ -198,7 +203,7 @@ public final class CubeRenderer {
 
     }
 
-    public static void render(BoundingBox bb, IIcon[] icons, VertexTransform xForm, boolean tintSides) {
+    public void render(BoundingBox bb, IIcon[] icons, VertexTransform xForm, boolean tintSides) {
         float[] brightnessPerSide = null;
         if (tintSides) {
             brightnessPerSide = new float[6];
@@ -209,7 +214,7 @@ public final class CubeRenderer {
         render(bb, icons, xForm, brightnessPerSide);
     }
 
-    public static void render(BoundingBox bb, IIcon[] faceTextures, VertexTransform xForm, float[] brightnessPerSide) {
+    public void render(BoundingBox bb, IIcon[] faceTextures, VertexTransform xForm, float[] brightnessPerSide) {
         setupVertices(bb, xForm);
         float minU;
         float maxU;
@@ -217,7 +222,7 @@ public final class CubeRenderer {
         float maxV;
         IIcon tex;
 
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
 
         tessellator.setNormal(0, 0, -1);
         if (brightnessPerSide != null) {
@@ -311,11 +316,11 @@ public final class CubeRenderer {
         addVecWithUV(verts[3], minU, minV);
     }
 
-    public static void setupVertices(BoundingBox bound) {
+    public void setupVertices(BoundingBox bound) {
         setupVertices(bound, null);
     }
 
-    public static void setupVertices(BoundingBox bound, VertexTransform xForm) {
+    public void setupVertices(BoundingBox bound, VertexTransform xForm) {
         verts[0].set(bound.minX, bound.minY, bound.minZ);
         verts[1].set(bound.maxX, bound.minY, bound.minZ);
         verts[2].set(bound.maxX, bound.maxY, bound.minZ);
@@ -332,10 +337,8 @@ public final class CubeRenderer {
         }
     }
 
-    public static void addVecWithUV(Vector3d vec, double u, double v) {
+    public void addVecWithUV(Vector3d vec, double u, double v) {
         Tessellator.instance.addVertexWithUV(vec.x, vec.y, vec.z, u, v);
     }
-
-    private CubeRenderer() {}
 
 }

--- a/src/main/java/com/enderio/core/client/render/CustomCubeRenderer.java
+++ b/src/main/java/com/enderio/core/client/render/CustomCubeRenderer.java
@@ -10,7 +10,11 @@ import com.enderio.core.api.client.render.IRenderFace;
 
 public class CustomCubeRenderer {
 
-    public static final CustomCubeRenderer instance = new CustomCubeRenderer();
+    private static final ThreadLocal<CustomCubeRenderer> instance = ThreadLocal.withInitial(CustomCubeRenderer::new);
+
+    public static CustomCubeRenderer get() {
+        return instance.get();
+    }
 
     private CustomRenderBlocks rb = null;
 

--- a/src/main/java/com/enderio/core/client/render/IconUtil.java
+++ b/src/main/java/com/enderio/core/client/render/IconUtil.java
@@ -21,7 +21,7 @@ public class IconUtil {
         public int getTextureType();
     }
 
-    private static ArrayList<IIconProvider> iconProviders = new ArrayList<IIconProvider>();
+    private static ArrayList<IIconProvider> iconProviders = new ArrayList<>();
 
     public static IIcon whiteTexture;
     public static IIcon blankTexture;

--- a/src/main/java/com/enderio/core/client/render/RenderUtil.java
+++ b/src/main/java/com/enderio/core/client/render/RenderUtil.java
@@ -257,15 +257,16 @@ public class RenderUtil {
         Block block = world.getBlock(x, y, z);
         int res = block == null ? world.getLightBrightnessForSkyBlocks(x, y, z, 0)
                 : block.getMixedBrightnessForBlock(world, x, y, z);
-        Tessellator.instance.setBrightness(res);
-        Tessellator.instance.setColorRGBA_F(1, 1, 1, 1);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setBrightness(res);
+        tessellator.setColorRGBA_F(1, 1, 1, 1);
         return res;
     }
 
     public static void renderQuad2D(double x, double y, double z, double width, double height, int colorRGB) {
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glDisable(GL11.GL_TEXTURE_2D);
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.setColorOpaque_I(colorRGB);
         tessellator.addVertex(x, y + height, z);
@@ -279,7 +280,7 @@ public class RenderUtil {
     public static void renderQuad2D(double x, double y, double z, double width, double height, Vector4f colorRGBA) {
         GL11.glColor4f(colorRGBA.x, colorRGBA.y, colorRGBA.z, colorRGBA.w);
         GL11.glDisable(GL11.GL_TEXTURE_2D);
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.addVertex(x, y + height, z);
         tessellator.addVertex(x + width, y + height, z);
@@ -706,7 +707,7 @@ public class RenderUtil {
         float width = fnt.getStringWidth(toRender);
         float height = fnt.FONT_HEIGHT;
         float padding = 2f;
-        Tessellator tessellator = Tessellator.instance;
+        final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
         tessellator.setColorRGBA_F(color.x, color.y, color.z, color.w);
         tessellator.addVertex(-padding, -padding, 0);

--- a/src/main/java/com/enderio/core/client/render/SimpleModelRenderer.java
+++ b/src/main/java/com/enderio/core/client/render/SimpleModelRenderer.java
@@ -11,8 +11,6 @@ import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 
 public class SimpleModelRenderer implements ISimpleBlockRenderingHandler {
 
-    private final Tessellator tes = Tessellator.instance;
-
     private final WavefrontObject model;
 
     private final int renderId;
@@ -29,6 +27,7 @@ public class SimpleModelRenderer implements ISimpleBlockRenderingHandler {
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer) {
+        final Tessellator tes = Tessellator.instance;
         RenderHelper.disableStandardItemLighting();
         tes.startDrawingQuads();
         tes.setColorOpaque_F(1, 1, 1);
@@ -40,6 +39,7 @@ public class SimpleModelRenderer implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
             RenderBlocks renderer) {
+        final Tessellator tes = Tessellator.instance;
         tes.setBrightness(block.getMixedBrightnessForBlock(world, x, y, z));
         tes.setColorOpaque_F(1, 1, 1);
         tes.addTranslation(x + .5F, y + .5F, z + .5F);

--- a/src/main/java/com/enderio/core/client/render/TechneUtil.java
+++ b/src/main/java/com/enderio/core/client/render/TechneUtil.java
@@ -64,8 +64,6 @@ public class TechneUtil {
 
     private static final TechneModelLoader modelLoader = new TechneModelLoader();
 
-    private static final Tessellator tes = Tessellator.instance;
-
     public static List<GroupObject> bakeModel(ModelRenderer model, TechneModel supermodel) {
         return bakeModel(model, supermodel, 1);
     }
@@ -352,6 +350,7 @@ public class TechneUtil {
 
     public static void renderInventoryBlock(Collection<GroupObject> model, IIcon icon, Block block, int metadata,
             RenderBlocks rb) {
+        final Tessellator tes = Tessellator.instance;
         tes.startDrawingQuads();
         tes.setColorOpaque_F(1, 1, 1);
         tes.addTranslation(0, -0.47f, 0);
@@ -363,6 +362,7 @@ public class TechneUtil {
 
     public static void renderInventoryBlock(GroupObject model, Block block, int metadata, RenderBlocks rb) {
         IIcon icon = getIconFor(block, metadata);
+        final Tessellator tes = Tessellator.instance;
         tes.startDrawingQuads();
         tes.setColorOpaque_F(1, 1, 1);
         tes.addTranslation(0, -0.47f, 0);
@@ -383,6 +383,7 @@ public class TechneUtil {
         if (icon == null) {
             return false;
         }
+        final Tessellator tes = Tessellator.instance;
         tes.setBrightness(block.getMixedBrightnessForBlock(world, x, y, z));
         tes.setColorOpaque_F(1, 1, 1);
         tes.addTranslation(x + .5F, y + 0.0375f, z + .5F);
@@ -395,6 +396,7 @@ public class TechneUtil {
     public static boolean renderWorldBlock(GroupObject model, IBlockAccess world, int x, int y, int z, Block block,
             RenderBlocks rb) {
         IIcon icon = getIconFor(block, world, x, y, z);
+        final Tessellator tes = Tessellator.instance;
         tes.setBrightness(block.getMixedBrightnessForBlock(world, x, y, z));
         tes.setColorOpaque_F(1, 1, 1);
         tes.addTranslation(x + .5F, y + 0.0375f, z + .5F);

--- a/src/main/java/com/enderio/core/client/render/VertexTransformComposite.java
+++ b/src/main/java/com/enderio/core/client/render/VertexTransformComposite.java
@@ -26,22 +26,22 @@ public class VertexTransformComposite implements VertexTransform {
 
     @Override
     public void apply(Vertex vertex) {
-        for (VertexTransform xform : xforms) {
-            xform.apply(vertex);
+        for (int i = 0; i < xforms.length; i++) {
+            xforms[i].apply(vertex);
         }
     }
 
     @Override
     public void apply(Vector3d vec) {
-        for (VertexTransform xform : xforms) {
-            xform.apply(vec);
+        for (int i = 0; i < xforms.length; i++) {
+            xforms[i].apply(vec);
         }
     }
 
     @Override
     public void applyToNormal(Vector3f vec) {
-        for (VertexTransform xform : xforms) {
-            xform.applyToNormal(vec);
+        for (int i = 0; i < xforms.length; i++) {
+            xforms[i].applyToNormal(vec);
         }
     }
 


### PR DESCRIPTION
* Make CubeRenderer & CustomCubeRenderer instanced and use a ThreadLocal
* Misc reduction of required Tessellator ASM and no more static tessellators
* Misc allocation reduction


NOTE: Not backwards compatible -- Will need a corresponding PR in dependent repos, of which I have only found EnderIO in our organization