### PR TITLE
Fix NEI optional again

### DIFF
--- a/src/main/java/com/enderio/core/EnderCore.java
+++ b/src/main/java/com/enderio/core/EnderCore.java
@@ -28,13 +28,16 @@ import com.enderio.core.common.network.EnderPacketHandler;
 import com.enderio.core.common.util.EnderFileUtils;
 import com.enderio.core.common.util.PermanentCache;
 import com.enderio.core.common.util.TextureErrorRemover;
+import com.enderio.core.compat.nei.EnderCoreContainerObjectHandler;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
+import codechicken.nei.guihook.GuiContainerManager;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms.IMCEvent;
@@ -63,6 +66,8 @@ public class EnderCore implements IEnderMod {
     @SidedProxy(serverSide = "com.enderio.core.common.CommonProxy", clientSide = "com.enderio.core.client.ClientProxy")
     public static CommonProxy proxy;
 
+    public static boolean isNEILoaded;
+
     public List<IConfigHandler> configs = Lists.newArrayList();
 
     @EventHandler
@@ -74,8 +79,13 @@ public class EnderCore implements IEnderMod {
                     lang.localize("error.ttcore.3"));
         }
 
+        isNEILoaded = Loader.isModLoaded("NotEnoughItems");
+
         if (event.getSide().isClient()) {
             TextureErrorRemover.beginIntercepting();
+            if (isNEILoaded) {
+                registerNEICompat();
+            }
         }
 
         ConfigHandler.configFolder = event.getModConfigurationDirectory();
@@ -155,5 +165,10 @@ public class EnderCore implements IEnderMod {
     @Override
     public String version() {
         return EnderCoreTags.VERSION;
+    }
+
+    @Optional.Method(modid = "NotEnoughItems")
+    private void registerNEICompat() {
+        GuiContainerManager.addObjectHandler(new EnderCoreContainerObjectHandler());
     }
 }

--- a/src/main/java/com/enderio/core/client/gui/GuiContainerBase.java
+++ b/src/main/java/com/enderio/core/client/gui/GuiContainerBase.java
@@ -1,5 +1,7 @@
 package com.enderio.core.client.gui;
 
+import static com.enderio.core.EnderCore.isNEILoaded;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -34,15 +36,10 @@ import codechicken.nei.ItemPanels;
 import codechicken.nei.VisiblityData;
 import codechicken.nei.api.INEIGuiHandler;
 import codechicken.nei.api.TaggedInventoryArea;
-import codechicken.nei.guihook.GuiContainerManager;
-import codechicken.nei.guihook.IContainerObjectHandler;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 
-@Optional.InterfaceList({ @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems"),
-        @Optional.Interface(iface = "codechicken.nei.guihook.IContainerObjectHandler", modid = "NotEnoughItems") })
-public abstract class GuiContainerBase extends GuiContainer
-        implements ToolTipRenderer, IGuiScreen, INEIGuiHandler, IContainerObjectHandler {
+@Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
+public abstract class GuiContainerBase extends GuiContainer implements ToolTipRenderer, IGuiScreen, INEIGuiHandler {
 
     protected ToolTipManager ttMan = new ToolTipManager();
     protected List<IGuiOverlay> overlays = Lists.newArrayList();
@@ -58,9 +55,6 @@ public abstract class GuiContainerBase extends GuiContainer
 
     protected VScrollbar draggingScrollbar;
 
-    protected static boolean registeredNEIHandler;
-    protected final boolean isNEILoaded = Loader.isModLoaded("NotEnoughItems");
-
     protected GuiContainerBase(Container par1Container) {
         super(par1Container);
     }
@@ -74,11 +68,6 @@ public abstract class GuiContainerBase extends GuiContainer
         }
         for (TextFieldEnder f : textFields) {
             f.init(this);
-        }
-
-        if (isNEILoaded && !registeredNEIHandler) {
-            GuiContainerManager.addObjectHandler(this);
-            registeredNEIHandler = true;
         }
     }
 
@@ -705,40 +694,5 @@ public abstract class GuiContainerBase extends GuiContainer
     @Optional.Method(modid = "NotEnoughItems")
     public boolean hideItemPanelSlot(GuiContainer gc, int x, int y, int w, int h) {
         return false;
-    }
-
-    // IContainerObjectHandler
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public void guiTick(GuiContainer guiContainer) {}
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public void refresh(GuiContainer guiContainer) {}
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public void load(GuiContainer guiContainer) {}
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public ItemStack getStackUnderMouse(GuiContainer guiContainer, int mouseX, int mouseY) {
-        if (guiContainer instanceof GuiContainerBase) {
-            return ((GuiContainerBase) guiContainer).getHoveredStack(mouseX, mouseY);
-        }
-        return null;
-    }
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public boolean objectUnderMouse(GuiContainer guiContainer, int mouseX, int mouseY) {
-        return false;
-    }
-
-    @Override
-    @Optional.Method(modid = "NotEnoughItems")
-    public boolean shouldShowTooltip(GuiContainer guiContainer) {
-        return true;
     }
 }

--- a/src/main/java/com/enderio/core/common/transform/EnderCorePlugin.java
+++ b/src/main/java/com/enderio/core/common/transform/EnderCorePlugin.java
@@ -2,6 +2,9 @@ package com.enderio.core.common.transform;
 
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 
@@ -12,6 +15,7 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 public class EnderCorePlugin implements IFMLLoadingPlugin {
 
     public static boolean runtimeDeobfEnabled = false;
+    public static final Logger logger = LogManager.getLogger("EnderCore");
 
     @Override
     public String[] getASMTransformerClass() {

--- a/src/main/java/com/enderio/core/common/transform/EnderCoreTransformer.java
+++ b/src/main/java/com/enderio/core/common/transform/EnderCoreTransformer.java
@@ -24,8 +24,6 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
 
-import com.enderio.core.EnderCore;
-
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 
 @MCVersion(value = "1.7.10")
@@ -289,7 +287,7 @@ public class EnderCoreTransformer implements IClassTransformer {
 
     protected final byte[] transform(byte[] classBytes, String className, ObfSafeName methodName,
             Transform transformer) {
-        EnderCore.logger.info("Transforming Class [" + className + "], Method [" + methodName.getName() + "]");
+        EnderCorePlugin.logger.info("Transforming Class [" + className + "], Method [" + methodName.getName() + "]");
 
         ClassNode classNode = new ClassNode();
         ClassReader classReader = new ClassReader(classBytes);
@@ -301,7 +299,7 @@ public class EnderCoreTransformer implements IClassTransformer {
 
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         classNode.accept(cw);
-        EnderCore.logger.info("Transforming " + className + " Finished.");
+        EnderCorePlugin.logger.info("Transforming " + className + " Finished.");
         return cw.toByteArray();
     }
 }

--- a/src/main/java/com/enderio/core/compat/nei/EnderCoreContainerObjectHandler.java
+++ b/src/main/java/com/enderio/core/compat/nei/EnderCoreContainerObjectHandler.java
@@ -1,0 +1,38 @@
+package com.enderio.core.compat.nei;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.ItemStack;
+
+import com.enderio.core.client.gui.GuiContainerBase;
+
+import codechicken.nei.guihook.IContainerObjectHandler;
+
+public class EnderCoreContainerObjectHandler implements IContainerObjectHandler {
+
+    @Override
+    public void guiTick(GuiContainer guiContainer) {}
+
+    @Override
+    public void refresh(GuiContainer guiContainer) {}
+
+    @Override
+    public void load(GuiContainer guiContainer) {}
+
+    @Override
+    public ItemStack getStackUnderMouse(GuiContainer guiContainer, int mouseX, int mouseY) {
+        if (guiContainer instanceof GuiContainerBase) {
+            return ((GuiContainerBase) guiContainer).getHoveredStack(mouseX, mouseY);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean objectUnderMouse(GuiContainer guiContainer, int mouseX, int mouseY) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldShowTooltip(GuiContainer guiContainer) {
+        return true;
+    }
+}


### PR DESCRIPTION
- Separate `IContainerObjectHandler` implementation from `GuiContainerBase`. Forge somehow tries to load classes inside of dynamic methods on clinit...
- Replace mention to `EnderCore.logger` in class transformers which causes cascading class loading.