### PR TITLE
Sickle AoE Right Click to Harvest

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,8 @@ dependencies {
     implementation('com.github.GTNewHorizons:GTNHLib:0.9.0:dev')
     implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.50-GTNH:dev")
     compileOnly("curse.maven:cofh-core-69162:2388750-dev:dev")
+    compileOnly("curse.maven:redstone-arsenal-70631:2277490-dev:dev")
+    compileOnly("curse.maven:magia-naturalis-1365176:7156285-dev")
 
     // for testing
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:EnderIO:2.10.12:dev") { transitive = false }

--- a/src/main/java/com/enderio/core/common/config/ConfigHandler.java
+++ b/src/main/java/com/enderio/core/common/config/ConfigHandler.java
@@ -49,8 +49,12 @@ public class ConfigHandler extends AbstractConfigHandler implements ITweakConfig
     public static boolean betterAchievements = true;
 
     @Config
-    @Comment("Disabling this option will prevent any crops added to the config json from being right clickable.")
+    @Comment("Disabling this option will prevent any crops added to the config json from being right clickable with an empty hand.")
     public static boolean allowCropRC = true;
+
+    @Config
+    @Comment("Enabling this option will allow Sickle tools to AoE right click harvest any crops added to the config json.")
+    public static boolean allowSickleRC = false;
 
     @Config
     @Comment("Prevent tick speedup (i.e. torcherino) on any TE that uses the base TE class from EnderCore")

--- a/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
+++ b/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
@@ -3,7 +3,13 @@ package com.enderio.core.common.handlers;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemTool;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import net.minecraftforge.event.world.BlockEvent.HarvestDropsEvent;
@@ -12,8 +18,12 @@ import net.minecraftforge.oredict.OreDictionary;
 import com.enderio.core.common.Handlers.Handler;
 import com.enderio.core.common.config.ConfigHandler;
 import com.enderio.core.common.util.ItemUtil;
+import com.enderio.core.common.util.ToolUtil;
+import com.github.elenterius.magianaturalis.item.artifact.SickleItem;
 import com.google.common.collect.Lists;
 
+import cofh.core.item.tool.ItemSickleAdv;
+import cofh.redstonearsenal.item.tool.ItemSickleRF;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 
@@ -63,18 +73,40 @@ public class RightClickCropHandler {
         int x = event.x, y = event.y, z = event.z;
         Block block = event.world.getBlock(x, y, z);
         int meta = event.world.getBlockMetadata(x, y, z);
-        if (ConfigHandler.allowCropRC && event.action == Action.RIGHT_CLICK_BLOCK
-                && (event.entityPlayer.getHeldItem() == null || !event.entityPlayer.isSneaking())) {
+
+        ItemStack stack = event.entityPlayer.getHeldItem();
+        int range = getRange(stack);
+
+        boolean handHarvest = ConfigHandler.allowCropRC && (stack == null && !event.entityPlayer.isSneaking());
+        boolean sickleHarvest = ConfigHandler.allowSickleRC && range > 0;
+
+        if ((handHarvest || sickleHarvest) && event.action == Action.RIGHT_CLICK_BLOCK
+                && !(event.entityPlayer instanceof FakePlayer)) {
             for (PlantInfo info : plants) {
                 if (info.blockInst == block && meta == info.meta) {
                     if (event.world.isRemote) {
                         event.entityPlayer.swingItem();
                     } else {
-                        currentPlant = info;
-                        block.dropBlockAsItem(event.world, x, y, z, meta, 0);
-                        currentPlant = null;
-                        event.world.setBlockMetadataWithNotify(x, y, z, info.resetMeta, 3);
-                        event.setCanceled(true);
+                        int fortune = 0;
+                        int cropsHarvested = 0;
+
+                        if (sickleHarvest) {
+                            fortune = EnchantmentHelper.getEnchantmentLevel(Enchantment.fortune.effectId, stack);
+                        }
+
+                        for (int i = x - range; i <= x + range; i++) {
+                            for (int k = z - range; k <= z + range; k++)
+                                if (info.blockInst == event.world.getBlock(i, y, k)
+                                        && event.world.getBlockMetadata(i, y, k) == info.meta) {
+                                            currentPlant = info;
+                                            block.dropBlockAsItem(event.world, i, y, k, meta, fortune);
+                                            cropsHarvested++;
+                                            currentPlant = null;
+                                            event.world.setBlockMetadataWithNotify(i, y, k, info.resetMeta, 3);
+                                            event.setCanceled(true);
+                                        }
+                        }
+                        damageDurability(stack, cropsHarvested, event.entityPlayer);
                     }
                     break;
                 }
@@ -95,5 +127,31 @@ public class RightClickCropHandler {
                 }
             }
         }
+    }
+
+    public int getRange(ItemStack tool) {
+        if (tool != null) {
+            Item item = tool.getItem();
+            int defaultValue = 3;
+
+            // Magia Naturalis
+            if (item instanceof SickleItem) return defaultValue;
+
+            // Redstone Arsenal
+            if (item instanceof ItemSickleRF) {
+                if (!ToolUtil.canDoEnergyOperations(tool)) return 1;
+                else if (((ItemSickleRF) item).isEmpowered(tool)) return 5;
+            }
+
+            // Thermal Foundation
+            if (item instanceof ItemSickleAdv) return ((ItemSickleAdv) item).radius;
+        }
+        return 0;
+    }
+
+    public void damageDurability(ItemStack tool, int cropsHarvested, EntityPlayer player) {
+        if (ToolUtil.usesEnergy(tool, cropsHarvested)) return;
+
+        if (tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
     }
 }

--- a/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
+++ b/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
@@ -82,7 +82,6 @@ public class RightClickCropHandler {
                         event.entityPlayer.swingItem();
                     } else {
                         int fortune = 0;
-                        int cropsHarvested = 0;
 
                         if (sickleHarvest) {
                             fortune = EnchantmentHelper.getEnchantmentLevel(Enchantment.fortune.effectId, stack);
@@ -94,13 +93,14 @@ public class RightClickCropHandler {
                                         && event.world.getBlockMetadata(i, y, k) == info.meta) {
                                             currentPlant = info;
                                             block.dropBlockAsItem(event.world, i, y, k, meta, fortune);
-                                            cropsHarvested++;
                                             currentPlant = null;
                                             event.world.setBlockMetadataWithNotify(i, y, k, info.resetMeta, 3);
                                             event.setCanceled(true);
+
+                                            if (!ToolUtil.damageDurability(stack, event.entityPlayer)) return;
                                         }
+
                         }
-                        ToolUtil.damageDurability(stack, cropsHarvested, event.entityPlayer);
                     }
                     break;
                 }

--- a/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
+++ b/src/main/java/com/enderio/core/common/handlers/RightClickCropHandler.java
@@ -5,10 +5,7 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemTool;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
@@ -19,11 +16,8 @@ import com.enderio.core.common.Handlers.Handler;
 import com.enderio.core.common.config.ConfigHandler;
 import com.enderio.core.common.util.ItemUtil;
 import com.enderio.core.common.util.ToolUtil;
-import com.github.elenterius.magianaturalis.item.artifact.SickleItem;
 import com.google.common.collect.Lists;
 
-import cofh.core.item.tool.ItemSickleAdv;
-import cofh.redstonearsenal.item.tool.ItemSickleRF;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 
@@ -75,7 +69,7 @@ public class RightClickCropHandler {
         int meta = event.world.getBlockMetadata(x, y, z);
 
         ItemStack stack = event.entityPlayer.getHeldItem();
-        int range = getRange(stack);
+        int range = ToolUtil.getRange(stack);
 
         boolean handHarvest = ConfigHandler.allowCropRC && (stack == null && !event.entityPlayer.isSneaking());
         boolean sickleHarvest = ConfigHandler.allowSickleRC && range > 0;
@@ -106,7 +100,7 @@ public class RightClickCropHandler {
                                             event.setCanceled(true);
                                         }
                         }
-                        damageDurability(stack, cropsHarvested, event.entityPlayer);
+                        ToolUtil.damageDurability(stack, cropsHarvested, event.entityPlayer);
                     }
                     break;
                 }
@@ -129,29 +123,4 @@ public class RightClickCropHandler {
         }
     }
 
-    public int getRange(ItemStack tool) {
-        if (tool != null) {
-            Item item = tool.getItem();
-            int defaultValue = 3;
-
-            // Magia Naturalis
-            if (item instanceof SickleItem) return defaultValue;
-
-            // Redstone Arsenal
-            if (item instanceof ItemSickleRF) {
-                if (!ToolUtil.canDoEnergyOperations(tool)) return 1;
-                else if (((ItemSickleRF) item).isEmpowered(tool)) return 5;
-            }
-
-            // Thermal Foundation
-            if (item instanceof ItemSickleAdv) return ((ItemSickleAdv) item).radius;
-        }
-        return 0;
-    }
-
-    public void damageDurability(ItemStack tool, int cropsHarvested, EntityPlayer player) {
-        if (ToolUtil.usesEnergy(tool, cropsHarvested)) return;
-
-        if (tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
-    }
 }

--- a/src/main/java/com/enderio/core/common/util/ToolUtil.java
+++ b/src/main/java/com/enderio/core/common/util/ToolUtil.java
@@ -1,0 +1,47 @@
+package com.enderio.core.common.util;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemStack;
+
+import cofh.lib.util.helpers.MathHelper;
+import cofh.redstonearsenal.item.tool.ItemSickleRF;
+
+public class ToolUtil {
+
+    public static boolean canDoEnergyOperations(ItemStack stack) {
+        if (stack.getItem() instanceof ItemSickleRF) {
+            ItemSickleRF sickle = (ItemSickleRF) stack.getItem();
+
+            boolean isEmpowered = sickle.isEmpowered(stack);
+            int unbreakingLevel = MathHelper
+                    .clamp((EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack)), 0, 4);
+            int costRF = sickle.energyPerUse * (5 - unbreakingLevel) / 5;
+
+            if (sickle.getEnergyStored(stack) > costRF) {
+                sickle.extractEnergy(
+                        stack,
+                        isEmpowered ? sickle.energyPerUseCharged * (5 - unbreakingLevel) / 5
+                                : sickle.energyPerUse * (5 - unbreakingLevel) / 5,
+                        false);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean usesEnergy(ItemStack tool, int cropsHarvested) {
+        if (tool.getItem() instanceof ItemSickleRF) {
+            ItemSickleRF RFTool = (ItemSickleRF) tool.getItem();
+            int unbreakingLvl = MathHelper
+                    .clamp(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, tool), 0, 4);
+            int RFCost = RFTool.isEmpowered(tool) ? RFTool.energyPerUseCharged * (5 - unbreakingLvl) / 5
+                    : RFTool.energyPerUse * (5 - unbreakingLvl) / 5;
+
+            RFTool.extractEnergy(tool, RFCost, false);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/enderio/core/common/util/ToolUtil.java
+++ b/src/main/java/com/enderio/core/common/util/ToolUtil.java
@@ -40,7 +40,7 @@ public class ToolUtil {
     public static void damageDurability(ItemStack tool, int cropsHarvested, EntityPlayer player) {
         if (ToolUtil.usesEnergy(tool, cropsHarvested)) return;
 
-        if (tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
+        if (tool != null && tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
     }
 
     public static boolean canDoEnergyOperations(ItemStack stack) {

--- a/src/main/java/com/enderio/core/common/util/ToolUtil.java
+++ b/src/main/java/com/enderio/core/common/util/ToolUtil.java
@@ -2,15 +2,49 @@ package com.enderio.core.common.util;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemTool;
 
+import com.github.elenterius.magianaturalis.item.artifact.SickleItem;
+
+import cofh.core.item.tool.ItemSickleAdv;
 import cofh.lib.util.helpers.MathHelper;
 import cofh.redstonearsenal.item.tool.ItemSickleRF;
+import cpw.mods.fml.common.Loader;
 
 public class ToolUtil {
 
+    public static final boolean isMagiaNaturalisLoaded = Loader.isModLoaded("magianaturalis");
+    public static final boolean isRedstoneArsenalLoaded = Loader.isModLoaded("RedstoneArsenal");
+    public static final boolean isCoFHCoreLoaded = Loader.isModLoaded("CoFHCore");
+
+    public static int getRange(ItemStack tool) {
+        if (tool != null) {
+            Item item = tool.getItem();
+            int defaultValue = 3;
+
+            if (isMagiaNaturalisLoaded && item instanceof SickleItem) return defaultValue;
+
+            if (isRedstoneArsenalLoaded && item instanceof ItemSickleRF) {
+                if (!ToolUtil.canDoEnergyOperations(tool)) return 1;
+                else if (((ItemSickleRF) item).isEmpowered(tool)) return 5;
+            }
+
+            if (isCoFHCoreLoaded && item instanceof ItemSickleAdv) return ((ItemSickleAdv) item).radius;
+        }
+        return 0;
+    }
+
+    public static void damageDurability(ItemStack tool, int cropsHarvested, EntityPlayer player) {
+        if (ToolUtil.usesEnergy(tool, cropsHarvested)) return;
+
+        if (tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
+    }
+
     public static boolean canDoEnergyOperations(ItemStack stack) {
-        if (stack.getItem() instanceof ItemSickleRF) {
+        if (ToolUtil.isRedstoneArsenalLoaded && stack.getItem() instanceof ItemSickleRF) {
             ItemSickleRF sickle = (ItemSickleRF) stack.getItem();
 
             boolean isEmpowered = sickle.isEmpowered(stack);
@@ -32,7 +66,7 @@ public class ToolUtil {
     }
 
     public static boolean usesEnergy(ItemStack tool, int cropsHarvested) {
-        if (tool.getItem() instanceof ItemSickleRF) {
+        if (ToolUtil.isRedstoneArsenalLoaded && tool.getItem() instanceof ItemSickleRF) {
             ItemSickleRF RFTool = (ItemSickleRF) tool.getItem();
             int unbreakingLvl = MathHelper
                     .clamp(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, tool), 0, 4);

--- a/src/main/java/com/enderio/core/common/util/ToolUtil.java
+++ b/src/main/java/com/enderio/core/common/util/ToolUtil.java
@@ -52,7 +52,7 @@ public class ToolUtil {
                     .clamp((EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack)), 0, 4);
             int costRF = sickle.energyPerUse * (5 - unbreakingLevel) / 5;
 
-            if (sickle.getEnergyStored(stack) > costRF) {
+            if (sickle.getEnergyStored(stack) >= costRF) {
                 sickle.extractEnergy(
                         stack,
                         isEmpowered ? sickle.energyPerUseCharged * (5 - unbreakingLevel) / 5

--- a/src/main/java/com/enderio/core/common/util/ToolUtil.java
+++ b/src/main/java/com/enderio/core/common/util/ToolUtil.java
@@ -28,7 +28,7 @@ public class ToolUtil {
             if (isMagiaNaturalisLoaded && item instanceof SickleItem) return defaultValue;
 
             if (isRedstoneArsenalLoaded && item instanceof ItemSickleRF) {
-                if (!ToolUtil.canDoEnergyOperations(tool)) return 1;
+                if (!ToolUtil.canDoEnergyOperations(tool, true)) return 1;
                 else if (((ItemSickleRF) item).isEmpowered(tool)) return 5;
             }
 
@@ -37,27 +37,14 @@ public class ToolUtil {
         return 0;
     }
 
-    public static void damageDurability(ItemStack tool, int cropsHarvested, EntityPlayer player) {
-        if (ToolUtil.usesEnergy(tool, cropsHarvested)) return;
+    public static boolean damageDurability(ItemStack stack, EntityPlayer player) {
+        if (stack != null) {
+            Item tool = stack.getItem();
+            if (ToolUtil.isRedstoneArsenalLoaded && tool instanceof ItemSickleRF)
+                return ToolUtil.canDoEnergyOperations(stack, false);
 
-        if (tool != null && tool.getItem() instanceof ItemTool) tool.damageItem(cropsHarvested, player);
-    }
-
-    public static boolean canDoEnergyOperations(ItemStack stack) {
-        if (ToolUtil.isRedstoneArsenalLoaded && stack.getItem() instanceof ItemSickleRF) {
-            ItemSickleRF sickle = (ItemSickleRF) stack.getItem();
-
-            boolean isEmpowered = sickle.isEmpowered(stack);
-            int unbreakingLevel = MathHelper
-                    .clamp((EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack)), 0, 4);
-            int costRF = sickle.energyPerUse * (5 - unbreakingLevel) / 5;
-
-            if (sickle.getEnergyStored(stack) >= costRF) {
-                sickle.extractEnergy(
-                        stack,
-                        isEmpowered ? sickle.energyPerUseCharged * (5 - unbreakingLevel) / 5
-                                : sickle.energyPerUse * (5 - unbreakingLevel) / 5,
-                        false);
+            if (tool instanceof ItemTool && tool.isDamageable()) {
+                stack.damageItem(1, player);
                 return true;
             }
         }
@@ -65,17 +52,23 @@ public class ToolUtil {
         return false;
     }
 
-    public static boolean usesEnergy(ItemStack tool, int cropsHarvested) {
-        if (ToolUtil.isRedstoneArsenalLoaded && tool.getItem() instanceof ItemSickleRF) {
-            ItemSickleRF RFTool = (ItemSickleRF) tool.getItem();
-            int unbreakingLvl = MathHelper
-                    .clamp(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, tool), 0, 4);
-            int RFCost = RFTool.isEmpowered(tool) ? RFTool.energyPerUseCharged * (5 - unbreakingLvl) / 5
-                    : RFTool.energyPerUse * (5 - unbreakingLvl) / 5;
+    public static boolean canDoEnergyOperations(ItemStack stack, boolean simulate) {
+        ItemSickleRF sickle = (ItemSickleRF) stack.getItem();
 
-            RFTool.extractEnergy(tool, RFCost, false);
-            return true;
+        if (sickle != null) {
+            boolean isEmpowered = sickle.isEmpowered(stack);
+
+            int unbreakingLevel = MathHelper
+                    .clamp((EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack)), 0, 4);
+
+            int costRF = (isEmpowered ? sickle.energyPerUseCharged : sickle.energyPerUse) * (5 - unbreakingLevel) / 5;
+
+            if (sickle.getEnergyStored(stack) >= costRF) {
+                if (!simulate) sickle.extractEnergy(stack, costRF, false);
+                return true;
+            }
         }
+
         return false;
     }
 }


### PR DESCRIPTION
EnderCore's Right Click to Harvest makes the harvesting tools provided by other mods obsolete. This PR integrates the two together.

Added config to right click to harvest to modded Sickles (Thermal Foundation, Redstone Arsenal & Magia Naturalis).
Durability and Fortune on tools will also be applied on harvest just as it would on left click.

Scythes will not included:
Scythes are large bladed instruments for mowing, while the Sickle are small curved hand blades for harvesting crops.
<img width="612" height="561" alt="image" src="https://github.com/user-attachments/assets/aba949f8-3be2-4064-b586-083014862916" />
> *Image: Woman with a Sickle next to a men with a Scythe*