### PR TITLE
[Memory-opti:fix leak] fix world client leak in CustomCubeRenderer

### DIFF
--- a/src/main/java/com/enderio/core/client/render/CustomCubeRenderer.java
+++ b/src/main/java/com/enderio/core/client/render/CustomCubeRenderer.java
@@ -36,6 +36,7 @@ public class CustomCubeRenderer {
         }
         rb.setRenderBoundsFromBlock(par1Block);
         rb.renderStandardBlock(par1Block, par2, par3, par4);
+        rb.blockAccess = null;
     }
 
     public void renderBlock(IBlockAccess ba, Block par1Block, int par2, int par3, int par4,
@@ -48,6 +49,7 @@ public class CustomCubeRenderer {
         rb.setFaceRenderers(renderers);
         rb.setRenderBoundsFromBlock(par1Block);
         rb.renderStandardBlock(par1Block, par2, par3, par4);
+        rb.blockAccess = null;
     }
 
     public IIcon getOverrideTexture() {


### PR DESCRIPTION
<img width="589" height="288" alt="image" src="https://github.com/user-attachments/assets/278c528b-6922-4f2c-98ea-32541cc151c7" />
